### PR TITLE
Move chalk from devDependencies to regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "body-parser": "^1.2.0",
     "broccoli-asset-rev": "0.3.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "chalk": "^0.5.1",
     "ember-cli": "0.1.2",
     "ember-cli-bourbon": "0.0.5",
     "ember-cli-compass-compiler": "0.0.17",
@@ -38,5 +37,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },
-  "dependencies": {}
+  "dependencies": {
+    "chalk": "^0.5.1"
+  }
 }


### PR DESCRIPTION
Fixes:

```
% ember g proto-scss
version: 0.1.2
Cannot find module 'chalk'
Error: Cannot find module 'chalk'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/zach/code/reddit/node_modules/ember-cli-proto-css/blueprints/proto-scss/index.js:3:13)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```
